### PR TITLE
Fix token export and order book error handling

### DIFF
--- a/services/upstoxService.js
+++ b/services/upstoxService.js
@@ -30,7 +30,7 @@ async function getToken(authCode) {
 
 
 
-async function getOrderBook(){
+async function getOrderBook() {
     try {
         const orderBookResponse = await axios.get('https://api.upstox.com/v2/order/retrieve-all', {
             headers: {
@@ -41,7 +41,8 @@ async function getOrderBook(){
         return orderBookResponse.data;
     } catch (error) {
         console.error('Failed to fetch order book:', error);
-        res.status(500).send('Failed to fetch order book');
+        // Rethrow the error so the caller can handle it
+        throw error;
     }
 }
 
@@ -61,4 +62,6 @@ module.exports = {
     getToken,
     getShortTermPositions,
     getOrderBook,
+    // Export tokens so middleware can access expiry information
+    tokens,
 };


### PR DESCRIPTION
## Summary
- export `tokens` from `upstoxService`
- throw errors from `getOrderBook` instead of using an undefined `res` object

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845793455e08322ae68ff6d2118b2d0